### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![pypi](https://pypip.in/v/fruitfly/badge.svg?style=flat)](https://pypi.python.org/pypi/fruitfly)
+[![pypi](https://img.shields.io/pypi/v/fruitfly.svg?style=flat)](https://pypi.python.org/pypi/fruitfly)
 
 Fruitfly
 ========


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fruitfly))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fruitfly`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.